### PR TITLE
protexec: allow using memfd_create for file backing creation (#34)

### DIFF
--- a/sljit_src/sljitProtExecAllocator.c
+++ b/sljit_src/sljitProtExecAllocator.c
@@ -108,6 +108,13 @@ static SLJIT_INLINE int create_tempfile(void)
 	char *dir;
 	size_t len;
 
+#ifdef HAVE_MEMFD_CREATE
+	/* this is a GNU extension, make sure to use -D_GNU_SOURCE */
+	fd = memfd_create("sljit", MFD_CLOEXEC);
+	if (fd != -1)
+		return fd;
+#endif
+
 #ifdef P_tmpdir
 	len = (P_tmpdir != NULL) ? strlen(P_tmpdir) : 0;
 


### PR DESCRIPTION
memfd_create is available in linux since kernel 3.17 with support
added in glibc (2.27), musl (1.1.20) and bionic (30).

it allows creating a tmpfs backed file without having to worry about
file system support, path location, permission or even file name
so is ideal for the kind of file that the ProtExecutionAllocator
needs to back its maps.

this solves the problems reported in PCRE's bug 2455[1] where a JIT
enabled call that was compiled to use this experimental allocator
will fail because the selected TMPDIR was non executable (ironically
something common in SE systems)

[1] https://bugs.exim.org/show_bug.cgi?id=2455